### PR TITLE
Added speed variable

### DIFF
--- a/receptor.ino
+++ b/receptor.ino
@@ -4,61 +4,68 @@
 SoftwareSerial mySerial(10, 11); // RX, TX
 LiquidCrystal lcd(12, 11, 5, 4, 3, 2);
 
-
 const uint8_t DEFAULT_FLAG = 0x7E; // 01111110 en binario
 
-void processFrameA(uint8_t* trama);
-void processFrameB(uint8_t* trama);
+void processFrameA(uint8_t *trama);
+void processFrameB(uint8_t *trama);
 void acknowledgeFrame(uint8_t NS);
 
+int speed = 0;
 
-void setup() {
-  Serial.begin(9600);  // Configura la velocidad de transmisión inicial (modificar según las pruebas)
-  mySerial.begin(9600);
+void setup()
+{
+  speed = 360;
+  Serial.begin(speed); // Configura la velocidad de transmisión inicial (modificar según las pruebas)
+  mySerial.begin(speed);
   lcd.begin(16, 2); // inicializa el LCD
   lcd.print("Iniciando prueba...");
 }
 
-void loop() {
-  if (mySerial.available()) {
+void loop()
+{
+  if (mySerial.available())
+  {
     lcd.clear();
     lcd.print("Prueba en curso...");
     uint8_t firstByte = mySerial.read();
 
-    if (firstByte == DEFAULT_FLAG) {
+    if (firstByte == DEFAULT_FLAG)
+    {
       uint8_t type = mySerial.read() & 0x07; // Extrae los 3 bits menos significativos para determinar el tipo
-      
-      switch (type) {
-        case 0x00: // Trama de control para inicio
-        case 0x03: // Trama de control para inicio (no primera)
-        case 0x04: // Trama de control para finalización
-          uint8_t frameA[9];
-          frameA[0] = DEFAULT_FLAG;
-          frameA[1] = tipo;
-          mySerial.readBytes(frameA + 2, 7); // Lee el resto de la trama
-          processFrameA(frameA);
-          break;
-        
-        case 0x01: // Trama de información
-          uint8_t frameB[205];
-          frameB[0] = BANDERA;
-          frameB[1] = tipo;
-          mySerial.readBytes(frameB + 2, 203); // Lee el resto de la trama
-          processFrameB(frameB);
-          break;
+
+      switch (type)
+      {
+      case 0x00: // Trama de control para inicio
+      case 0x03: // Trama de control para inicio (no primera)
+      case 0x04: // Trama de control para finalización
+        uint8_t frameA[9];
+        frameA[0] = DEFAULT_FLAG;
+        frameA[1] = tipo;
+        mySerial.readBytes(frameA + 2, 7); // Lee el resto de la trama
+        processFrameA(frameA);
+        break;
+
+      case 0x01: // Trama de información
+        uint8_t frameB[205];
+        frameB[0] = BANDERA;
+        frameB[1] = tipo;
+        mySerial.readBytes(frameB + 2, 203); // Lee el resto de la trama
+        processFrameB(frameB);
+        break;
 
         // Agregar otros tipos si es necesario
       }
     }
-    
+
     lcd.clear();
     lcd.print("Prueba Finalizada!");
-    lcd.setCursor(0,1);
+    lcd.setCursor(0, 1);
     lcd.print("BER: XX.xx %"); // Mostrar el BER calculado
   }
 }
 
-void processFrameA(uint8_t* frame) {
+void processFrameA(uint8_t *frame)
+{
   // Procesa la trama de tipo A (inicio/finalización)
   // Extrae y procesa la velocidad, tamaño de datos, etc.
 
@@ -67,18 +74,20 @@ void processFrameA(uint8_t* frame) {
   lcd.print("Trama A recibida");
 }
 
-void processFrameB(uint8_t* frame) {
+void processFrameB(uint8_t *frame)
+{
   // Procesa la trama de tipo B (información)
-  
+
   // Por ahora, solo muestra un mensaje en el LCD
   lcd.clear();
   lcd.print("Trama B recibida");
-  
+
   uint8_t NS = frame[1] >> 3; // Extrae el número de secuencia
   acknowledgeFrame(NS);
 }
 
-void acknowledgeFrame(uint8_t NS) {
+void acknowledgeFrame(uint8_t NS)
+{
   uint8_t frameACK[3] = {DEFAULT_FLAG, (NS << 3) | 0x05, DEFAULT_FLAG}; // Construye la trama ACK
   mySerial.write(frameACK, sizeof(frameACK));
 }

--- a/transmitter.ino
+++ b/transmitter.ino
@@ -12,45 +12,49 @@ const uint8_t DEFAULT_FLAG = 0x7E; // 01111110 en binario
 
 uint16_t calculateCRC(uint8_t *datos, size_t longitud);
 
-uint8_t* buildFrameA(uint8_t type, uint16_t speed, uint16_t dataSize) {
+uint8_t *buildFrameA(uint8_t type, uint16_t speed, uint16_t dataSize)
+{
   static uint8_t frameA[9]; // Estático para preservar el valor entre llamadas
-  
+
   tramaA[0] = DEFAULT_FLAG;
   tramaA[1] = type;
-  tramaA[2] = speed >> 8;   // byte alto de velocidad
-  tramaA[3] = speed & 0xFF; // byte bajo de velocidad
+  tramaA[2] = speed >> 8;      // byte alto de velocidad
+  tramaA[3] = speed & 0xFF;    // byte bajo de velocidad
   tramaA[4] = dataSize >> 8;   // byte alto de tamaño
   tramaA[5] = dataSize & 0xFF; // byte bajo de tamaño
-  
+
   uint16_t crc = calculateCRC(frameA + 1, 5); // Calcula el CRC de los datos en la trama (sin incluir banderas)
-  tramaA[6] = crc >> 8;   // byte alto de CRC
-  tramaA[7] = crc & 0xFF; // byte bajo de CRC
+  tramaA[6] = crc >> 8;                       // byte alto de CRC
+  tramaA[7] = crc & 0xFF;                     // byte bajo de CRC
   tramaA[8] = DEFAULT_FLAG;
 
   return frameA;
 }
 
-uint8_t* buildFrameB(uint8_t NS, uint8_t type, uint8_t* information) {
+uint8_t *buildFrameB(uint8_t NS, uint8_t type, uint8_t *information)
+{
   static uint8_t frameB[205];
 
   frameB[0] = DEFAULT_FLAG;
-  frameB[1] = (NS << 3) | type; // Desplaza NS 3 bits a la izquierda y OR con tipo
+  frameB[1] = (NS << 3) | type;         // Desplaza NS 3 bits a la izquierda y OR con tipo
   memcpy(tramaB + 2, information, 200); // Copia 200 bytes de información
-  
+
   uint16_t crc = calculateCRC(frameB + 1, 202); // Calcula el CRC de los datos en la trama (sin incluir banderas)
-  frameB[202] = crc >> 8;   // byte alto de CRC
-  frameB[203] = crc & 0xFF; // byte bajo de CRC
+  frameB[202] = crc >> 8;                       // byte alto de CRC
+  frameB[203] = crc & 0xFF;                     // byte bajo de CRC
   frameB[204] = DEFAULT_FLAG;
 
   return frameB;
 }
 
+int speed = 0;
 
 void setup()
 {
+  speed = 360;
   lcd.begin(16, 2);
-  Serial.begin(9600); // Configura la velocidad de transmisión inicial (modificar según las pruebas)
-  mySerial.begin(9600);
+  Serial.begin(speed); // Configura la velocidad de transmisión inicial (modificar según las pruebas)
+  mySerial.begin(speed);
 }
 
 void loop()


### PR DESCRIPTION
In order to implement a list with all the speeds that the test would need, we would have to have both arduinos serial communication baud rate (bps) be the same. In order to achieve this we would need to send it through serial and reset it on both ends before starting the actual experiment... So it's easier to just use a speed variable for both arduinos for now. After we manage to implement everything else, we could develop a better way to adjust the speeds for each experiment.